### PR TITLE
Delphi XE compatibility

### DIFF
--- a/Source/DelphiSpec.Scenario.pas
+++ b/Source/DelphiSpec.Scenario.pas
@@ -128,18 +128,17 @@ var
   I: Integer;
   RttiField: TRttiField;
   Values: TArray<TValue>;
-  TmpArr: packed array of Byte;
   ElementType: TRttiType;
 begin
   ElementType := (ParamType as TRttiDynamicArrayType).ElementType;
-  SetLength(TmpArr, ElementType.TypeSize);
 
   SetLength(Values, DataTable.Count);
   for I := 0 to DataTable.Count - 1 do
   begin
-    TValue.Make(@TmpArr[0], ElementType.Handle, Values[I]);
-    for RttiField in ElementType.AsRecord.GetDeclaredFields do
-      RttiField.SetValue(Values[I].GetReferenceToRawData, ConvertParamValue(DataTable[RttiField.Name][I], RttiField.FieldType));
+    TValue.Make(nil, ElementType.Handle, Values[I]);
+    for RttiField in ElementType.AsRecord.GetFields do
+      RttiField.SetValue(Values[I].GetReferenceToRawData,
+        ConvertParamValue(DataTable[RttiField.Name][I], RttiField.FieldType));
   end;
 
   Result := TValue.FromArray(ParamType.Handle, Values);


### PR DESCRIPTION
In XE GetDeclaredFields returns nil for TRttiRecordType but GetFields works for all Delphi versions (the GetDeclaredXXX methods ignore inheritance which does not matter for records).

Also I removed the temp buffer for creating TValue instances. TValue internally allocates memory for the wrapped record and as we start with an empty one we can pass nil.
